### PR TITLE
Fix property row drag

### DIFF
--- a/app/components/CustomNode.tsx
+++ b/app/components/CustomNode.tsx
@@ -140,6 +140,8 @@ const CustomNode = ({ data, id, isConnectable, ...props }: NodeProps<CustomNodeD
             key={p.key}
             draggable
             onDragStart={(e) => onDragStartRow(e, i)}
+            onMouseDown={(e) => e.stopPropagation()}
+            onPointerDown={(e) => e.stopPropagation()}
             style={{
               display: 'flex',
               justifyContent: 'space-between',


### PR DESCRIPTION
## Summary
- stop propagation on property row to avoid moving the entire node when dragging a property

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68876cbf83648333973c733e6d95109a